### PR TITLE
setting/RT-10: swagger 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ bin/
 
 ### env ###
 backend/.env
+backend/src/main/resources/env.properties
 
 ### db ###
 backend/db/

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,7 @@ bin/
 .DS_Store
 
 ### env ###
-backend/.env
-backend/src/main/resources/env.properties
+backend/env.properties
 
 ### db ###
 backend/db/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 tasks.named('test') {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,19 +1,19 @@
 services:
-  springboot:
-    image: "rushticket:latest"
-    build: .
-    env_file: .env
-    ports:
-      - "8080:8080"
-    environment:
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
-      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-    networks:
-      - rushticket-network
-    depends_on:
-      mysql:
-        condition: service_healthy
+#  springboot:
+#    image: "rushticket:latest"
+#    build: .
+#    env_file: .env
+#    ports:
+#      - "8080:8080"
+#    environment:
+#      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+#      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+#      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+#    networks:
+#      - rushticket-network
+#    depends_on:
+#      mysql:
+#        condition: service_healthy
   mysql:
     image: "mysql:8.0"
     environment:
@@ -26,11 +26,11 @@ services:
     volumes:
       - rushticket-db:/var/lib/mysql
     restart: always
-    healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${MYSQL_USER}", "-p${MYSQL_PASSWORD}" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+#    healthcheck:
+#      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${MYSQL_USER}", "-p${MYSQL_PASSWORD}" ]
+#      interval: 10s
+#      timeout: 5s
+#      retries: 5
     networks:
       - rushticket-network
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 #  springboot:
 #    image: "rushticket:latest"
 #    build: .
-#    env_file: .env
+#    env_file: env.properties
 #    ports:
 #      - "8080:8080"
 #    environment:

--- a/backend/src/main/java/com/nahowo/rushTicket/RushTicketApplication.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/RushTicketApplication.java
@@ -3,10 +3,12 @@ package com.nahowo.rushTicket;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @EntityScan(basePackages = {"com.nahowo.rushTicket.domain"})
+@PropertySource("classpath:env.properties")
 @SpringBootApplication
 public class RushTicketApplication {
 

--- a/backend/src/main/java/com/nahowo/rushTicket/RushTicketApplication.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/RushTicketApplication.java
@@ -3,12 +3,10 @@ package com.nahowo.rushTicket;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @EntityScan(basePackages = {"com.nahowo.rushTicket.domain"})
-@PropertySource("classpath:env.properties")
 @SpringBootApplication
 public class RushTicketApplication {
 

--- a/backend/src/main/java/com/nahowo/rushTicket/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/SwaggerConfig.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
 public class SwaggerConfig {

--- a/backend/src/main/java/com/nahowo/rushTicket/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.nahowo.rushTicket.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .components(new Components())
+            .info(apiInfo());
+    }
+    private Info apiInfo() {
+        return new Info()
+            .title("rushTicket API")
+            .description("rushTicket의 API 명세")
+            .version("1.0.0");
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         show_sql: true
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: "file:./env.properties"
   application:
     name: rushTicket
   jpa:


### PR DESCRIPTION
### 스프링 로컬 실행
- 개발 단계에서 스프링을 로컬에서 실행하도록 설정 변경
  - docker-compose.yml에서 springboot 서비스 주석처리
  - application.yml에서 mysql host를 mysql 컨테이너가 아니라 localhost로 변경(env.properties에서 환경변수 설정)

### swagger 설정
- build.gradle에 open API 의존성 추가
- config 패키지에 SwaggerConfig 클래스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added interactive API documentation (OpenAPI/Swagger UI) for the backend with basic metadata.
- Chores
  - Updated configuration to load environment variables from a properties file and adjusted Hibernate dialect.
  - Updated dependency to support API documentation.
  - Revised ignore patterns for environment files.
  - Modified Docker Compose: disabled the Spring Boot container and MySQL health check by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->