### PR TITLE
setting/RT-11: 공통 결과/예외 처리

### DIFF
--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "S001", "내부 서버 에러"),
-    USEREMAIL_DUPLICATED(HttpStatus.CONFLICT.value(), "U001", "유저 이메일 중복");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SE001", "내부 서버 에러"),
+    USEREMAIL_DUPLICATED(HttpStatus.CONFLICT.value(), "UE001", "유저 이메일 중복");
     private final int httpStatus;
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.nahowo.rushTicket.config.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "S001", "내부 서버 에러"),
+    USEREMAIL_DUPLICATED(HttpStatus.CONFLICT.value(), "U001", "유저 이메일 중복");
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.nahowo.rushTicket.config.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.nahowo.rushTicket.config.error;
+
+import com.nahowo.rushTicket.config.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // internal server error용 핸들러
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception) {
+        log.error(exception.getClass() + ": " + exception.getMessage());
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(new ErrorResponse(
+            errorCode.getCode(), errorCode.getMessage() + ": " + exception.getClass()));
+    }
+
+    // 커스텀 핸들러
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Object> handleRuntimeException(BusinessException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(new ErrorResponse(
+            errorCode.getCode(), errorCode.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/BusinessException.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.nahowo.rushTicket.config.error.exception;
+
+import com.nahowo.rushTicket.config.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/UserEmailDuplicatedException.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/UserEmailDuplicatedException.java
@@ -1,0 +1,12 @@
+package com.nahowo.rushTicket.config.error.exception;
+
+import com.nahowo.rushTicket.config.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserEmailDuplicatedException extends BusinessException {
+    public UserEmailDuplicatedException() {
+        super(ErrorCode.USEREMAIL_DUPLICATED);
+    }
+
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -1,0 +1,13 @@
+package com.nahowo.rushTicket.config.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+    USER_CREATE("U001", "회원 생성 성공");
+
+    private final String code;
+    private final String message;
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResultCode {
-    USER_CREATE("U001", "회원 생성 성공");
+    USER_CREATE("UR001", "회원 생성 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultResponse.java
@@ -1,0 +1,20 @@
+package com.nahowo.rushTicket.config.result;
+
+import lombok.Getter;
+
+@Getter
+public class ResultResponse {
+    private String code;
+    private String message;
+    private Object data;
+
+    public ResultResponse(ResultCode resultCode, Object data) {
+        this.code = resultCode.getCode();
+        this.message = resultCode.getMessage();
+        this.data = data;
+    }
+
+    public static ResultResponse of(ResultCode resultCode, Object data) {
+        return new ResultResponse(resultCode, data);
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/UserController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.nahowo.rushTicket.controller;
 
+import static com.nahowo.rushTicket.config.result.ResultCode.USER_CREATE;
+
+import com.nahowo.rushTicket.config.result.ResultResponse;
 import com.nahowo.rushTicket.dto.request.UserCreateRequest;
 import com.nahowo.rushTicket.dto.response.UserResponse;
 import com.nahowo.rushTicket.service.UserService;
@@ -21,8 +24,8 @@ public class UserController {
     private final UserService userService;
     @Operation(description = "User Registration")
     @PostMapping("/signup")
-    public ResponseEntity<String> createUser(@RequestBody @Valid UserCreateRequest userCreateReqeust) {
+    public ResponseEntity<ResultResponse> createUser(@RequestBody @Valid UserCreateRequest userCreateReqeust) {
         UserResponse user = userService.createUser(userCreateReqeust);
-        return ResponseEntity.ok(user.toString());
+        return ResponseEntity.ok(ResultResponse.of(USER_CREATE, user));
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/repository/UserRepository.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/repository/UserRepository.java
@@ -4,6 +4,4 @@ import com.nahowo.rushTicket.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-
-    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
@@ -1,5 +1,6 @@
 package com.nahowo.rushTicket.service;
 
+import com.nahowo.rushTicket.config.error.exception.UserEmailDuplicatedException;
 import com.nahowo.rushTicket.domain.User;
 import com.nahowo.rushTicket.dto.request.UserCreateRequest;
 import com.nahowo.rushTicket.dto.response.UserResponse;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class UserService {
     private final UserRepository userRepository;
 
@@ -20,19 +20,14 @@ public class UserService {
         String name = reqeust.name();
         String email = reqeust.email();
         String password = reqeust.password();
-        try {
-            isEmailDuplicated(email);
-        } catch (Exception e) {
-            log.error("이메일 중복: " + email);
-            return null;
-        }
+        isEmailDuplicated(email);
         User createdUser = userRepository.save(new User(name, email, password));
         return new UserResponse(createdUser);
     }
 
-    private void isEmailDuplicated(String email) throws Exception{
+    private void isEmailDuplicated(String email) {
         if (userRepository.existsByEmail(email)) {
-            throw new Exception();
+            throw new UserEmailDuplicatedException();
         }
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
@@ -7,6 +7,7 @@ import com.nahowo.rushTicket.dto.response.UserResponse;
 import com.nahowo.rushTicket.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -21,13 +22,10 @@ public class UserService {
         String name = reqeust.name();
         String email = reqeust.email();
         String password = passwordEncoder.encode(reqeust.password());
-        isEmailDuplicated(email);
-        User createdUser = userRepository.save(new User(name, email, password));
-        return new UserResponse(createdUser);
-    }
-
-    private void isEmailDuplicated(String email) {
-        if (userRepository.existsByEmail(email)) {
+        try {
+            User createdUser = userRepository.save(new User(name, email, password));
+            return new UserResponse(createdUser);
+        } catch (DataIntegrityViolationException e) {
             throw new UserEmailDuplicatedException();
         }
     }

--- a/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
@@ -7,19 +7,20 @@ import com.nahowo.rushTicket.dto.response.UserResponse;
 import com.nahowo.rushTicket.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public UserResponse createUser(UserCreateRequest reqeust) {
         String name = reqeust.name();
         String email = reqeust.email();
-        String password = reqeust.password();
+        String password = passwordEncoder.encode(reqeust.password());
         isEmailDuplicated(email);
         User createdUser = userRepository.save(new User(name, email, password));
         return new UserResponse(createdUser);


### PR DESCRIPTION
### result
- ResultCode enum: 코드, 메시지를 가지는 결과 enum 정의
- ResultResponse 클래스 작성: ResultCode를 받아서 반환하는 형식 정의

### error
- exception 패키지에 BusinessException(공통 예외 클래스), 개별 예외 클래스 작성
- errorCode enum: http 코드, 코드, 메시지를 가지는 예외 enum 정의
- ErrorResponse 클래스: 코드, 메시지를 가지는 형식 정의
- GlobalExceptionHandler: 범용 예외 핸들러 & 커스텀 예외 핸들러 메서드 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Standardized API responses: endpoints return a unified structure with code, message, and data.
  - Consistent error handling: centralized error responses with clear codes and messages.

- Changes
  - User signup now returns a structured success payload containing user data.
  - Passwords are now stored securely (encoded) during signup.

- Bug Fixes
  - Duplicate email during signup returns a conflict status with a specific error code and message.
  - General runtime errors are centrally handled and returned with appropriate HTTP statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->