### PR TITLE
feat/RT-27: 이벤트 예매 개발

### DIFF
--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     EVENT_ALREADY_STARTED(HttpStatus.BAD_REQUEST.value(), "EE002", "공연이 이미 시작됨"),
     EVENT_BOOKING_ALREADY_STARTED(HttpStatus.BAD_REQUEST.value(), "EE003", "공연 예매가 이미 시작됨"),
     VENUE_SEAT_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "SE001", "좌석 그룹을 찾을 수 없음"),
+    SEAT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "SE002", "좌석 상태를 찾을 수 없음"),
     EVENT_DATE_TIME_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "EDE001", "공연일시를 찾을 수 없음"),
     VENUE_RESERVATION_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "VRE001", "해당 공연장/일정이 이미 존재함");
     private final int httpStatus;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     SEAT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "SE002", "좌석 상태를 찾을 수 없음"),
     EVENT_DATE_TIME_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "EDE001", "공연일시를 찾을 수 없음"),
     VENUE_RESERVATION_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "VRE001", "해당 공연장/일정이 이미 존재함"),
-    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "TE001", "티켓을 찾을 수 없음");
+    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "TE001", "티켓을 찾을 수 없음"),
+    TICKET_ALREADY_CANCELED(HttpStatus.BAD_REQUEST.value(), "TE002", "티켓이 이미 취소됨"),
+    TICKET_ALREADY_USED(HttpStatus.BAD_REQUEST.value(), "TE003", "티켓이 이미 사용됨");
     private final int httpStatus;
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     VENUE_SEAT_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "SE001", "좌석 그룹을 찾을 수 없음"),
     SEAT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "SE002", "좌석 상태를 찾을 수 없음"),
     EVENT_DATE_TIME_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "EDE001", "공연일시를 찾을 수 없음"),
-    VENUE_RESERVATION_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "VRE001", "해당 공연장/일정이 이미 존재함");
+    VENUE_RESERVATION_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "VRE001", "해당 공연장/일정이 이미 존재함"),
+    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "TE001", "티켓을 찾을 수 없음");
     private final int httpStatus;
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/SeatStatusNotFoundException.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/SeatStatusNotFoundException.java
@@ -1,0 +1,10 @@
+package com.nahowo.rushTicket.config.error;
+
+import com.nahowo.rushTicket.config.error.exception.BusinessException;
+
+public class SeatStatusNotFoundException extends BusinessException {
+
+    public SeatStatusNotFoundException() {
+        super(ErrorCode.SEAT_STATUS_NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/TicketAlreadyCanceledException.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/TicketAlreadyCanceledException.java
@@ -1,0 +1,10 @@
+package com.nahowo.rushTicket.config.error.exception;
+
+import com.nahowo.rushTicket.config.error.ErrorCode;
+
+public class TicketAlreadyCanceledException extends BusinessException {
+
+    public TicketAlreadyCanceledException() {
+        super(ErrorCode.TICKET_ALREADY_CANCELED);
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/TicketAlreadyUsedException.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/TicketAlreadyUsedException.java
@@ -1,0 +1,10 @@
+package com.nahowo.rushTicket.config.error.exception;
+
+import com.nahowo.rushTicket.config.error.ErrorCode;
+
+public class TicketAlreadyUsedException extends BusinessException{
+
+    public TicketAlreadyUsedException() {
+        super(ErrorCode.TICKET_ALREADY_USED);
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/TicketNotFoundException.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/error/exception/TicketNotFoundException.java
@@ -1,0 +1,10 @@
+package com.nahowo.rushTicket.config.error.exception;
+
+import com.nahowo.rushTicket.config.error.ErrorCode;
+
+public class TicketNotFoundException extends BusinessException{
+
+    public TicketNotFoundException() {
+        super(ErrorCode.TICKET_NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -16,7 +16,8 @@ public enum ResultCode {
     EVENTS_VIEW("ER004", "이벤트 목록 조회 성공"),
     EVENT_VIEW("ER005", "이벤트 조회 성공"),
     SEAT_STATUS_VIEW("SR001", "공연 좌석 상태 조회 성공"),
-    SEAT_BOOK("SR002", "공연 좌석 예매 성공");
+    SEAT_BOOK("SR002", "공연 좌석 예매 성공"),
+    SEAT_CANCEL("SR003", "공연 좌석 취소 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -12,7 +12,9 @@ public enum ResultCode {
     VENUE_VIEW("VR002", "공연장 조회 성공"),
     EVENT_CREATE("ER001", "이벤트 등록 성공"),
     EVENT_UPDATE("ER002", "이벤트 수정 성공"),
-    EVENT_DELETE("ER003", "이벤트 삭제 성공");
+    EVENT_DELETE("ER003", "이벤트 삭제 성공"),
+    EVENTS_VIEW("ER004", "이벤트 목록 조회 성공"),
+    EVENT_VIEW("ER005", "이벤트 조회 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -17,7 +17,8 @@ public enum ResultCode {
     EVENT_VIEW("ER005", "이벤트 조회 성공"),
     SEAT_STATUS_VIEW("SR001", "공연 좌석 상태 조회 성공"),
     SEAT_BOOK("SR002", "공연 좌석 예매 성공"),
-    SEAT_CANCEL("SR003", "공연 좌석 취소 성공");
+    SEAT_CANCEL("SR003", "공연 좌석 취소 성공"),
+    SEAT_USED("SR004", "공연 티켓 사용 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -15,7 +15,8 @@ public enum ResultCode {
     EVENT_DELETE("ER003", "이벤트 삭제 성공"),
     EVENTS_VIEW("ER004", "이벤트 목록 조회 성공"),
     EVENT_VIEW("ER005", "이벤트 조회 성공"),
-    SEAT_STATUS_VIEW("SR001", "공연 좌석 상태 조회 성공");
+    SEAT_STATUS_VIEW("SR001", "공연 좌석 상태 조회 성공"),
+    SEAT_BOOK("SR002", "공연 좌석 예매 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/config/result/ResultCode.java
@@ -14,7 +14,8 @@ public enum ResultCode {
     EVENT_UPDATE("ER002", "이벤트 수정 성공"),
     EVENT_DELETE("ER003", "이벤트 삭제 성공"),
     EVENTS_VIEW("ER004", "이벤트 목록 조회 성공"),
-    EVENT_VIEW("ER005", "이벤트 조회 성공");
+    EVENT_VIEW("ER005", "이벤트 조회 성공"),
+    SEAT_STATUS_VIEW("SR001", "공연 좌석 상태 조회 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
@@ -63,6 +63,12 @@ public class EventController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_CANCEL));
     }
 
+    @PatchMapping("/useTicket/{ticketId}")
+    public ResponseEntity<ResultResponse> useTicket(@PathVariable Long ticketId) {
+        eventService.useTicket(ticketId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_USED));
+    }
+
     @PostMapping
     public ResponseEntity<ResultResponse> createEvent(
         @RequestBody @Valid EventCreateRequest request) {

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
@@ -4,6 +4,7 @@ import com.nahowo.rushTicket.config.result.ResultCode;
 import com.nahowo.rushTicket.config.result.ResultResponse;
 import com.nahowo.rushTicket.dto.request.EventCreateRequest;
 import com.nahowo.rushTicket.dto.request.EventUpdateRequest;
+import com.nahowo.rushTicket.dto.response.EventDetailResponse;
 import com.nahowo.rushTicket.dto.response.EventResponse;
 import com.nahowo.rushTicket.service.EventService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,13 +31,13 @@ public class EventController {
 
     @GetMapping
     public ResponseEntity<ResultResponse> viewEvents() {
-        List<EventResponse> events = eventService.viewEvents();
+        List<EventResponse> events = eventService.viewsEvents();
         return ResponseEntity.ok(ResultResponse.of(ResultCode.EVENTS_VIEW, events));
     }
 
     @GetMapping("/{eventId}")
     public ResponseEntity<ResultResponse> viewEvent(@PathVariable Long eventId) {
-        EventResponse event = eventService.viewEvent(eventId);
+        EventDetailResponse event = eventService.viewEvent(eventId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.EVENT_VIEW, event));
     }
 

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
@@ -7,6 +7,7 @@ import com.nahowo.rushTicket.dto.request.EventUpdateRequest;
 import com.nahowo.rushTicket.dto.response.EventDetailResponse;
 import com.nahowo.rushTicket.dto.response.EventResponse;
 import com.nahowo.rushTicket.dto.response.SeatStatusesResponse;
+import com.nahowo.rushTicket.dto.response.SeatStatusesResponse.SeatStatusResponse;
 import com.nahowo.rushTicket.service.EventService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -50,7 +51,11 @@ public class EventController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_STATUS_VIEW, seatStatuses));
     }
 
-    @PostMapping
+    @PostMapping("/bookSeat")
+    public ResponseEntity<ResultResponse> bookSeat(@RequestParam Long userId, @RequestParam Long seatStatusId) {
+        SeatStatusResponse seatStatus = eventService.bookSeat(userId, seatStatusId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_BOOK, seatStatus));
+    }
 
     public ResponseEntity<ResultResponse> createEvent(
         @RequestBody @Valid EventCreateRequest request) {

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
@@ -57,6 +57,13 @@ public class EventController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_BOOK, seatStatus));
     }
 
+    @PatchMapping("/cancelSeat/{ticketId}")
+    public ResponseEntity<ResultResponse> cancelSeat(@PathVariable Long ticketId) {
+        eventService.cancelSeat(ticketId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_CANCEL));
+    }
+
+    @PostMapping
     public ResponseEntity<ResultResponse> createEvent(
         @RequestBody @Valid EventCreateRequest request) {
         EventResponse event = eventService.createEvent(request);

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
@@ -8,9 +8,11 @@ import com.nahowo.rushTicket.dto.response.EventResponse;
 import com.nahowo.rushTicket.service.EventService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +28,20 @@ public class EventController {
 
     private final EventService eventService;
 
+    @GetMapping
+    public ResponseEntity<ResultResponse> viewEvents() {
+        List<EventResponse> events = eventService.viewEvents();
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.EVENTS_VIEW, events));
+    }
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<ResultResponse> viewEvent(@PathVariable Long eventId) {
+        EventResponse event = eventService.viewEvent(eventId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.EVENT_VIEW, event));
+    }
+
     @PostMapping
+
     public ResponseEntity<ResultResponse> createEvent(
         @RequestBody @Valid EventCreateRequest request) {
         EventResponse event = eventService.createEvent(request);

--- a/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/controller/EventController.java
@@ -6,6 +6,7 @@ import com.nahowo.rushTicket.dto.request.EventCreateRequest;
 import com.nahowo.rushTicket.dto.request.EventUpdateRequest;
 import com.nahowo.rushTicket.dto.response.EventDetailResponse;
 import com.nahowo.rushTicket.dto.response.EventResponse;
+import com.nahowo.rushTicket.dto.response.SeatStatusesResponse;
 import com.nahowo.rushTicket.service.EventService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Events")
@@ -39,6 +41,13 @@ public class EventController {
     public ResponseEntity<ResultResponse> viewEvent(@PathVariable Long eventId) {
         EventDetailResponse event = eventService.viewEvent(eventId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.EVENT_VIEW, event));
+    }
+
+    @GetMapping("/eventSeats/{eventId}")
+    public ResponseEntity<ResultResponse> viewSeatsStatus(@PathVariable Long eventId,
+        @RequestParam Long eventDateTimeId) {
+        SeatStatusesResponse seatStatuses = eventService.viewSeatStatus(eventId, eventDateTimeId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.SEAT_STATUS_VIEW, seatStatuses));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/Event.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/Event.java
@@ -14,12 +14,14 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @Table(name = "events")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@SQLRestriction("is_deleted = false")
 public class Event extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seller_id", nullable = false)

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/Seat.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/Seat.java
@@ -8,9 +8,11 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
 @Table(name = "seats")
+@Getter
 public class Seat extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "venue_id", nullable = false)

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/Seat.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/Seat.java
@@ -22,12 +22,4 @@ public class Seat extends BaseEntity {
 
     @Column(name = "seat_number", nullable = false)
     private String seatNumber;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private SeatStatus status;
-
-    public enum SeatStatus {
-        AVAILABLE, BOOKED, LOCKED
-    }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/SeatStatus.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/SeatStatus.java
@@ -1,0 +1,33 @@
+package com.nahowo.rushTicket.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "seat_status")
+public class SeatStatus extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_date_time_id", nullable = false)
+    private EventDateTime eventDateTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    public enum Status {
+        AVAILABLE, BOOKED, LOCKED
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/SeatStatus.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/SeatStatus.java
@@ -34,4 +34,8 @@ public class SeatStatus extends BaseEntity {
     public void bookSeat() {
         this.status = Status.BOOKED;
     }
+
+    public void cancelSeat() {
+        this.status = Status.AVAILABLE;
+    }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/SeatStatus.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/SeatStatus.java
@@ -30,4 +30,8 @@ public class SeatStatus extends BaseEntity {
     public enum Status {
         AVAILABLE, BOOKED, LOCKED
     }
+
+    public void bookSeat() {
+        this.status = Status.BOOKED;
+    }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/Ticket.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/Ticket.java
@@ -49,4 +49,8 @@ public class Ticket extends BaseEntity{
     public void cancelTicket() {
         this.status = TicketStatus.CANCELED;
     }
+
+    public void useTicket() {
+        this.status = TicketStatus.USED;
+    }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/Ticket.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/Ticket.java
@@ -9,9 +9,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "tickets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Ticket extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "buyer_id", nullable = false)
@@ -22,8 +27,8 @@ public class Ticket extends BaseEntity{
     private Price price;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seat_id", nullable = false)
-    private Seat seat;
+    @JoinColumn(name = "seat_status_id", nullable = false)
+    private SeatStatus seatStatus;
 
     @Column(name = "qr_code", nullable = false, unique = true)
     private String qrCode;

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/Ticket.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/Ticket.java
@@ -11,12 +11,14 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "tickets")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Getter
 public class Ticket extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "buyer_id", nullable = false)
@@ -42,5 +44,9 @@ public class Ticket extends BaseEntity{
 
     public enum TicketStatus {
         BOOKED, USED, CANCELED
+    }
+
+    public void cancelTicket() {
+        this.status = TicketStatus.CANCELED;
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/domain/VenueSeatGroup.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/domain/VenueSeatGroup.java
@@ -6,7 +6,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
+@Getter
 @Entity
 @Table(name = "venue_seat_groups")
 public class VenueSeatGroup extends BaseEntity{

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/EventDetailResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/EventDetailResponse.java
@@ -1,6 +1,8 @@
 package com.nahowo.rushTicket.dto.response;
 
 import com.nahowo.rushTicket.domain.Event;
+import com.nahowo.rushTicket.domain.EventDateTime;
+import com.nahowo.rushTicket.domain.VenueSeatGroup;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,31 +13,34 @@ public record EventDetailResponse (
     LocalDateTime booking_end_time,
     String description,
     String name,
-    List<EventTimeResponse> eventTimeResponses
+    List<EventDateResponse> eventDateResponses,
+    List<VenueSeatGroupResponse> venueSeatGroupResponses
 )
 {
-
-    public static EventDetailResponse of(Event event, List<EventTimeResponse> eventTimeResponses) {
+    public static EventDetailResponse of(Event event, List<EventDateResponse> eventDateResponses, List<VenueSeatGroupResponse> venueSeatGroupResponses) {
         return new EventDetailResponse(event.getId(), event.getBookingStartTime(),
             event.getBookingEndTime(), event.getDescription(), event.getName(),
-            eventTimeResponses);
+            eventDateResponses, venueSeatGroupResponses);
     }
 
     public record EventDateResponse(
         LocalDate eventDate,
-        List<EventTimeResponse> eventTimeResponses
+        List<LocalDateTime> eventDateTimes
     ) {
-    }
 
-    public record EventTimeResponse(
-        LocalDateTime eventDateTime,
-        List<VenueSeatGroupResponse> venueSeatGroupResponses
-    ) {
+        public static EventDateResponse of(LocalDate eventDate, List<LocalDateTime> eventDateTimes) {
+            return new EventDateResponse(eventDate, eventDateTimes);
+        }
     }
 
     public record VenueSeatGroupResponse(
         String groupName,
         Integer seatsCount
     ) {
+
+        public static VenueSeatGroupResponse of(VenueSeatGroup venueSeatGroup) {
+            return new VenueSeatGroupResponse(venueSeatGroup.getGroupName(),
+                venueSeatGroup.getSeatsCount());
+        }
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/EventDetailResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/EventDetailResponse.java
@@ -1,0 +1,41 @@
+package com.nahowo.rushTicket.dto.response;
+
+import com.nahowo.rushTicket.domain.Event;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record EventDetailResponse (
+    Long id,
+    LocalDateTime booking_start_time,
+    LocalDateTime booking_end_time,
+    String description,
+    String name,
+    List<EventTimeResponse> eventTimeResponses
+)
+{
+
+    public static EventDetailResponse of(Event event, List<EventTimeResponse> eventTimeResponses) {
+        return new EventDetailResponse(event.getId(), event.getBookingStartTime(),
+            event.getBookingEndTime(), event.getDescription(), event.getName(),
+            eventTimeResponses);
+    }
+
+    public record EventDateResponse(
+        LocalDate eventDate,
+        List<EventTimeResponse> eventTimeResponses
+    ) {
+    }
+
+    public record EventTimeResponse(
+        LocalDateTime eventDateTime,
+        List<VenueSeatGroupResponse> venueSeatGroupResponses
+    ) {
+    }
+
+    public record VenueSeatGroupResponse(
+        String groupName,
+        Integer seatsCount
+    ) {
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/EventResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/EventResponse.java
@@ -2,21 +2,17 @@ package com.nahowo.rushTicket.dto.response;
 
 import com.nahowo.rushTicket.domain.Event;
 import java.time.LocalDateTime;
-import lombok.Getter;
 
-@Getter
-public class EventResponse {
-    private Long id;
-    private LocalDateTime booking_start_time;
-    private LocalDateTime booking_end_time;
-    private String description;
-    private String name;
+public record EventResponse (
+    Long id,
+    LocalDateTime booking_start_time,
+    LocalDateTime booking_end_time,
+    String description,
+    String name
+    ) {
 
-    public EventResponse(Event event) {
-        this.id = event.getId();
-        this.booking_start_time = event.getBookingStartTime();
-        this.booking_end_time = event.getBookingEndTime();
-        this.description = event.getDescription();
-        this.name = event.getName();
+    public static EventResponse of(Event event) {
+        return new EventResponse(event.getId(), event.getBookingStartTime(),
+            event.getBookingEndTime(), event.getDescription(), event.getName());
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/SeatStatusesResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/SeatStatusesResponse.java
@@ -1,0 +1,22 @@
+package com.nahowo.rushTicket.dto.response;
+
+import com.nahowo.rushTicket.domain.SeatStatus;
+import com.nahowo.rushTicket.domain.SeatStatus.Status;
+import java.util.List;
+
+public record SeatStatusesResponse(
+    List<SeatStatusResponse> seatStatuses
+) {
+    public record SeatStatusResponse (
+        Long id,
+        Status status,
+        Long seatId,
+        Long eventDateTimeId
+    ) {
+
+        public static SeatStatusResponse of(SeatStatus seatStatus) {
+            return new SeatStatusResponse(seatStatus.getId(), seatStatus.getStatus(),
+                seatStatus.getSeat().getId(), seatStatus.getEventDateTime().getId());
+        }
+    }
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/UserResponse.java
@@ -1,17 +1,13 @@
 package com.nahowo.rushTicket.dto.response;
 
 import com.nahowo.rushTicket.domain.User;
-import lombok.Getter;
 
-@Getter
-public class UserResponse {
-    private Long id;
-    private String name;
-    private String email;
-
-    public UserResponse(User user) {
-        this.id = user.getId();
-        this.name = user.getName();
-        this.email = user.getEmail();
+public record UserResponse (
+    Long id,
+    String name,
+    String email
+) {
+    public static UserResponse of(User user) {
+        return new UserResponse(user.getId(), user.getName(), user.getEmail());
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/VenueDetailResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/VenueDetailResponse.java
@@ -4,19 +4,15 @@ import com.nahowo.rushTicket.domain.Venue;
 import com.nahowo.rushTicket.domain.enums.VenueStatus;
 import java.time.LocalDate;
 import java.util.TreeMap;
-import lombok.Getter;
 
-@Getter
-public class VenueDetailResponse {
-    private Long id;
-    private String name;
-    private Integer totalSeats;
-    private TreeMap<LocalDate, VenueStatus> venueAvailabilities;
-
-    public VenueDetailResponse(Venue venue, TreeMap<LocalDate, VenueStatus> availabilities) {
-        this.id = venue.getId();
-        this.name = venue.getName();
-        this.totalSeats = venue.getTotalSeats();
-        this.venueAvailabilities = availabilities;
+public record VenueDetailResponse (
+    Long id,
+    String name,
+    Integer totalSeats,
+    TreeMap<LocalDate, VenueStatus> venueAvailabilities
+) {
+    public static VenueDetailResponse of(Venue venue, TreeMap<LocalDate, VenueStatus> availabilities) {
+        return new VenueDetailResponse(venue.getId(), venue.getName(), venue.getTotalSeats(),
+            availabilities);
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/dto/response/VenueResponse.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/dto/response/VenueResponse.java
@@ -1,17 +1,13 @@
 package com.nahowo.rushTicket.dto.response;
 
 import com.nahowo.rushTicket.domain.Venue;
-import lombok.Getter;
 
-@Getter
-public class VenueResponse {
-    private Long id;
-    private String name;
-    private Integer totalSeats;
-
-    public VenueResponse(Venue venue) {
-        this.id = venue.getId();
-        this.name = venue.getName();
-        this.totalSeats = venue.getTotalSeats();
+public record VenueResponse (
+    Long id,
+    String name,
+    Integer totalSeats
+) {
+    public static VenueResponse of(Venue venue) {
+        return new VenueResponse(venue.getId(), venue.getName(), venue.getTotalSeats());
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/repository/PriceRepository.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/repository/PriceRepository.java
@@ -2,11 +2,14 @@ package com.nahowo.rushTicket.repository;
 
 import com.nahowo.rushTicket.domain.EventDateTime;
 import com.nahowo.rushTicket.domain.Price;
+import com.nahowo.rushTicket.domain.VenueSeatGroup;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PriceRepository extends JpaRepository<Price, Long> {
 
     List<Price> findAllByEventDateTime(EventDateTime eventDateTime);
+
+    Price findByEventDateTimeAndVenueSeatGroup(EventDateTime eventDateTime, VenueSeatGroup venueSeatGroup);
 
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/repository/SeatRepository.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/repository/SeatRepository.java
@@ -1,0 +1,10 @@
+package com.nahowo.rushTicket.repository;
+
+import com.nahowo.rushTicket.domain.Seat;
+import com.nahowo.rushTicket.domain.Venue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    Seat findByVenue(Venue venue);
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/repository/SeatStatusRepository.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/repository/SeatStatusRepository.java
@@ -1,0 +1,12 @@
+package com.nahowo.rushTicket.repository;
+
+import com.nahowo.rushTicket.domain.EventDateTime;
+import com.nahowo.rushTicket.domain.Seat;
+import com.nahowo.rushTicket.domain.SeatStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatStatusRepository extends JpaRepository<SeatStatus, Long> {
+
+    List<SeatStatus> findAllBySeatAndEventDateTime(Seat seat, EventDateTime eventDateTime);
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/repository/TicketRepository.java
@@ -1,0 +1,8 @@
+package com.nahowo.rushTicket.repository;
+
+import com.nahowo.rushTicket.domain.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+}

--- a/backend/src/main/java/com/nahowo/rushTicket/repository/VenueSeatGroupRepository.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/repository/VenueSeatGroupRepository.java
@@ -1,8 +1,11 @@
 package com.nahowo.rushTicket.repository;
 
+import com.nahowo.rushTicket.domain.Venue;
 import com.nahowo.rushTicket.domain.VenueSeatGroup;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VenueSeatGroupRepository extends JpaRepository<VenueSeatGroup, Long> {
 
+    List<VenueSeatGroup> findByVenue(Venue venue);
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -20,6 +20,9 @@ import com.nahowo.rushTicket.dto.request.EventCreateRequest.DateSeatGroupPrice;
 import com.nahowo.rushTicket.dto.request.EventCreateRequest.EventTimeAndPrice;
 import com.nahowo.rushTicket.dto.request.EventCreateRequest.SeatGroupPrice;
 import com.nahowo.rushTicket.dto.request.EventUpdateRequest;
+import com.nahowo.rushTicket.dto.response.EventDetailResponse;
+import com.nahowo.rushTicket.dto.response.EventDetailResponse.EventDateResponse;
+import com.nahowo.rushTicket.dto.response.EventDetailResponse.VenueSeatGroupResponse;
 import com.nahowo.rushTicket.dto.response.EventResponse;
 import com.nahowo.rushTicket.repository.EventDateTimeRepository;
 import com.nahowo.rushTicket.repository.EventRepository;
@@ -32,7 +35,10 @@ import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -49,7 +55,7 @@ public class EventService {
     private final PriceRepository priceRepository;
 
     @Transactional
-    public List<EventResponse> viewEvents() {
+    public List<EventResponse> viewsEvents() {
         List<Event> events = eventRepository.findAll();
         return events.stream()
             .map(EventResponse::of)
@@ -57,10 +63,30 @@ public class EventService {
     }
 
     @Transactional
-    public EventResponse viewEvent(Long eventId) {
+    public EventDetailResponse viewEvent(Long eventId) {
         Event event = eventRepository.findById(eventId)
             .orElseThrow(EventNotFoundException::new);
-        return EventResponse.of(event);
+
+        List<EventDateTime> eventDateTimes = eventDateTimeRepository.findAllByEvent(event);
+        Map<LocalDate, List<LocalDateTime>> eventDateMap = new TreeMap<>();
+        for (EventDateTime eventDateTime : eventDateTimes) {
+            LocalDate localDate = eventDateTime.getEventStartTime().toLocalDate();
+            LocalDateTime eventStartTime = eventDateTime.getEventStartTime();
+            if (eventDateMap.containsKey(localDate)) {
+                eventDateMap.get(localDate).add(eventStartTime);
+            } else {
+                eventDateMap.put(localDate, List.of(eventStartTime));
+            }
+        }
+        List<EventDateResponse> eventDateResponses = eventDateMap.entrySet().stream()
+            .map(entry -> EventDateResponse.of(entry.getKey(), entry.getValue()))
+            .toList();
+
+        Venue venue = event.getVenue();
+        List<VenueSeatGroupResponse> venueSeatGroupResponses = venueSeatGroupRepository.findByVenue(venue).stream()
+            .map(VenueSeatGroupResponse::of)
+            .toList();
+        return EventDetailResponse.of(event, eventDateResponses, venueSeatGroupResponses);
     }
 
     @Transactional

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -5,6 +5,8 @@ import com.nahowo.rushTicket.config.error.exception.EventAlreadyStartedException
 import com.nahowo.rushTicket.config.error.exception.EventBookingAlreadyStartedException;
 import com.nahowo.rushTicket.config.error.exception.EventDateTimeNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.EventNotFoundException;
+import com.nahowo.rushTicket.config.error.exception.TicketAlreadyCanceledException;
+import com.nahowo.rushTicket.config.error.exception.TicketAlreadyUsedException;
 import com.nahowo.rushTicket.config.error.exception.TicketNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.UserNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.VenueNotFoundException;
@@ -139,6 +141,12 @@ public class EventService {
         Ticket ticket = ticketRepository.findById(ticketId)
             .orElseThrow(TicketNotFoundException::new);
         ticket.cancelTicket();
+        if (ticket.getStatus() == TicketStatus.CANCELED) {
+            throw new TicketAlreadyCanceledException();
+        }
+        if (ticket.getStatus() == TicketStatus.USED) {
+            throw new TicketAlreadyUsedException();
+        }
 
         SeatStatus seatStatus = ticket.getSeatStatus();
         seatStatus.cancelSeat();

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -1,5 +1,6 @@
 package com.nahowo.rushTicket.service;
 
+import com.nahowo.rushTicket.config.error.SeatStatusNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.EventAlreadyStartedException;
 import com.nahowo.rushTicket.config.error.exception.EventBookingAlreadyStartedException;
 import com.nahowo.rushTicket.config.error.exception.EventDateTimeNotFoundException;
@@ -14,6 +15,8 @@ import com.nahowo.rushTicket.domain.EventDateTime;
 import com.nahowo.rushTicket.domain.Price;
 import com.nahowo.rushTicket.domain.Seat;
 import com.nahowo.rushTicket.domain.SeatStatus;
+import com.nahowo.rushTicket.domain.Ticket;
+import com.nahowo.rushTicket.domain.Ticket.TicketStatus;
 import com.nahowo.rushTicket.domain.User;
 import com.nahowo.rushTicket.domain.Venue;
 import com.nahowo.rushTicket.domain.VenueReservation;
@@ -34,6 +37,7 @@ import com.nahowo.rushTicket.repository.EventRepository;
 import com.nahowo.rushTicket.repository.PriceRepository;
 import com.nahowo.rushTicket.repository.SeatRepository;
 import com.nahowo.rushTicket.repository.SeatStatusRepository;
+import com.nahowo.rushTicket.repository.TicketRepository;
 import com.nahowo.rushTicket.repository.UserRepository;
 import com.nahowo.rushTicket.repository.VenueRepository;
 import com.nahowo.rushTicket.repository.VenueReservationRepository;
@@ -61,6 +65,7 @@ public class EventService {
     private final PriceRepository priceRepository;
     private final SeatRepository seatRepository;
     private final SeatStatusRepository seatStatusRepository;
+    private final TicketRepository ticketRepository;
 
     @Transactional
     public List<EventResponse> viewsEvents() {
@@ -109,6 +114,23 @@ public class EventService {
             .map(SeatStatusResponse::of)
             .toList();
         return new SeatStatusesResponse(seatStatusResponses);
+    }
+
+    @Transactional
+    public SeatStatusResponse bookSeat(Long userId, Long seatStatusId) {
+        SeatStatus seatStatus = seatStatusRepository.findById(seatStatusId)
+            .orElseThrow(SeatStatusNotFoundException::new);
+        seatStatus.bookSeat();
+        EventDateTime eventDateTime = seatStatus.getEventDateTime();
+        VenueSeatGroup venueSeatGroup = seatStatus.getSeat().getVenueSeatGroup();
+        Price price = priceRepository.findByEventDateTimeAndVenueSeatGroup(
+            eventDateTime, venueSeatGroup);
+
+        User user = getUser(userId);
+        Ticket ticket = new Ticket(user, price, seatStatus, "qrcode", TicketStatus.BOOKED,
+            LocalDateTime.now());
+        ticketRepository.save(ticket);
+        return SeatStatusResponse.of(seatStatus);
     }
 
     @Transactional

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -140,16 +140,19 @@ public class EventService {
     public void cancelSeat(Long ticketId) {
         Ticket ticket = ticketRepository.findById(ticketId)
             .orElseThrow(TicketNotFoundException::new);
+        validateTicket(ticket);
         ticket.cancelTicket();
-        if (ticket.getStatus() == TicketStatus.CANCELED) {
-            throw new TicketAlreadyCanceledException();
-        }
-        if (ticket.getStatus() == TicketStatus.USED) {
-            throw new TicketAlreadyUsedException();
-        }
 
         SeatStatus seatStatus = ticket.getSeatStatus();
         seatStatus.cancelSeat();
+    }
+
+    @Transactional
+    public void useTicket(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+            .orElseThrow(TicketNotFoundException::new);
+        validateTicket(ticket);
+        ticket.useTicket();
     }
 
     @Transactional
@@ -185,6 +188,15 @@ public class EventService {
         Venue venue = event.getVenue();
         event.delete();
         deleteEventDateTimes(event, venue);
+    }
+
+    private static void validateTicket(Ticket ticket) {
+        if (ticket.getStatus() == TicketStatus.CANCELED) {
+            throw new TicketAlreadyCanceledException();
+        }
+        if (ticket.getStatus() == TicketStatus.USED) {
+            throw new TicketAlreadyUsedException();
+        }
     }
 
     private void createEventDateTimes(EventTimeAndPrice eventTimeAndPrice, Event event) {

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -5,6 +5,7 @@ import com.nahowo.rushTicket.config.error.exception.EventAlreadyStartedException
 import com.nahowo.rushTicket.config.error.exception.EventBookingAlreadyStartedException;
 import com.nahowo.rushTicket.config.error.exception.EventDateTimeNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.EventNotFoundException;
+import com.nahowo.rushTicket.config.error.exception.TicketNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.UserNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.VenueNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.VenueReservationAlreadyExistException;
@@ -127,10 +128,20 @@ public class EventService {
             eventDateTime, venueSeatGroup);
 
         User user = getUser(userId);
-        Ticket ticket = new Ticket(user, price, seatStatus, "qrcode", TicketStatus.BOOKED,
+        Ticket ticket = new Ticket(user, price, seatStatus, null, TicketStatus.BOOKED,
             LocalDateTime.now());
         ticketRepository.save(ticket);
         return SeatStatusResponse.of(seatStatus);
+    }
+
+    @Transactional
+    public void cancelSeat(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+            .orElseThrow(TicketNotFoundException::new);
+        ticket.cancelTicket();
+
+        SeatStatus seatStatus = ticket.getSeatStatus();
+        seatStatus.cancelSeat();
     }
 
     @Transactional

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -49,6 +49,21 @@ public class EventService {
     private final PriceRepository priceRepository;
 
     @Transactional
+    public List<EventResponse> viewEvents() {
+        List<Event> events = eventRepository.findAll();
+        return events.stream()
+            .map(EventResponse::new)
+            .toList();
+    }
+
+    @Transactional
+    public EventResponse viewEvent(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+            .orElseThrow(EventNotFoundException::new);
+        return new EventResponse(event);
+    }
+
+    @Transactional
     public EventResponse createEvent(EventCreateRequest request) {
         User user = getUser(request);
         Venue venue = getVenue(request);

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -52,7 +52,7 @@ public class EventService {
     public List<EventResponse> viewEvents() {
         List<Event> events = eventRepository.findAll();
         return events.stream()
-            .map(EventResponse::new)
+            .map(EventResponse::of)
             .toList();
     }
 
@@ -60,7 +60,7 @@ public class EventService {
     public EventResponse viewEvent(Long eventId) {
         Event event = eventRepository.findById(eventId)
             .orElseThrow(EventNotFoundException::new);
-        return new EventResponse(event);
+        return EventResponse.of(event);
     }
 
     @Transactional
@@ -74,7 +74,7 @@ public class EventService {
         for (EventTimeAndPrice eventTimeAndPrice : eventTimeAndPrices) {
             createEventDateTimes(eventTimeAndPrice, event);
         }
-        return new EventResponse(event);
+        return EventResponse.of(event);
     }
 
     @Transactional
@@ -84,7 +84,7 @@ public class EventService {
             throw new EventBookingAlreadyStartedException();
         }
         event.update(request);
-        return new EventResponse(event);
+        return EventResponse.of(event);
     }
 
     @Transactional

--- a/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/EventService.java
@@ -2,6 +2,7 @@ package com.nahowo.rushTicket.service;
 
 import com.nahowo.rushTicket.config.error.exception.EventAlreadyStartedException;
 import com.nahowo.rushTicket.config.error.exception.EventBookingAlreadyStartedException;
+import com.nahowo.rushTicket.config.error.exception.EventDateTimeNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.EventNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.UserNotFoundException;
 import com.nahowo.rushTicket.config.error.exception.VenueNotFoundException;
@@ -11,6 +12,8 @@ import com.nahowo.rushTicket.domain.Event;
 import com.nahowo.rushTicket.domain.Event.EventStatus;
 import com.nahowo.rushTicket.domain.EventDateTime;
 import com.nahowo.rushTicket.domain.Price;
+import com.nahowo.rushTicket.domain.Seat;
+import com.nahowo.rushTicket.domain.SeatStatus;
 import com.nahowo.rushTicket.domain.User;
 import com.nahowo.rushTicket.domain.Venue;
 import com.nahowo.rushTicket.domain.VenueReservation;
@@ -24,9 +27,13 @@ import com.nahowo.rushTicket.dto.response.EventDetailResponse;
 import com.nahowo.rushTicket.dto.response.EventDetailResponse.EventDateResponse;
 import com.nahowo.rushTicket.dto.response.EventDetailResponse.VenueSeatGroupResponse;
 import com.nahowo.rushTicket.dto.response.EventResponse;
+import com.nahowo.rushTicket.dto.response.SeatStatusesResponse;
+import com.nahowo.rushTicket.dto.response.SeatStatusesResponse.SeatStatusResponse;
 import com.nahowo.rushTicket.repository.EventDateTimeRepository;
 import com.nahowo.rushTicket.repository.EventRepository;
 import com.nahowo.rushTicket.repository.PriceRepository;
+import com.nahowo.rushTicket.repository.SeatRepository;
+import com.nahowo.rushTicket.repository.SeatStatusRepository;
 import com.nahowo.rushTicket.repository.UserRepository;
 import com.nahowo.rushTicket.repository.VenueRepository;
 import com.nahowo.rushTicket.repository.VenueReservationRepository;
@@ -35,7 +42,6 @@ import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -53,6 +59,8 @@ public class EventService {
     private final EventDateTimeRepository eventDateTimeRepository;
     private final VenueSeatGroupRepository venueSeatGroupRepository;
     private final PriceRepository priceRepository;
+    private final SeatRepository seatRepository;
+    private final SeatStatusRepository seatStatusRepository;
 
     @Transactional
     public List<EventResponse> viewsEvents() {
@@ -90,9 +98,23 @@ public class EventService {
     }
 
     @Transactional
+    public SeatStatusesResponse viewSeatStatus(Long eventId, Long eventDateTimeId) {
+        Event event = eventRepository.findById(eventId).orElseThrow(EventNotFoundException::new);
+        Venue venue = event.getVenue();
+        Seat seat = seatRepository.findByVenue(venue);
+        EventDateTime eventDateTime = eventDateTimeRepository.findById(eventDateTimeId).orElseThrow(
+            EventDateTimeNotFoundException::new);
+        List<SeatStatusResponse> seatStatusResponses = seatStatusRepository.findAllBySeatAndEventDateTime(
+                seat, eventDateTime).stream()
+            .map(SeatStatusResponse::of)
+            .toList();
+        return new SeatStatusesResponse(seatStatusResponses);
+    }
+
+    @Transactional
     public EventResponse createEvent(EventCreateRequest request) {
-        User user = getUser(request);
-        Venue venue = getVenue(request);
+        User user = getUser(request.userId());
+        Venue venue = getVenue(request.venueId());
 
         List<EventTimeAndPrice> eventTimeAndPrices = createEventTimeAndPrices(
             request, venue);
@@ -190,13 +212,11 @@ public class EventService {
         venueReservationRepository.save(venueReservation);
     }
 
-    private Venue getVenue(EventCreateRequest request) {
-        Long venueId = request.venueId();
+    private Venue getVenue(Long venueId) {
         return venueRepository.findById(venueId).orElseThrow(VenueNotFoundException::new);
     }
 
-    private User getUser(EventCreateRequest request) {
-        Long userId = request.userId();
+    private User getUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
     }
 

--- a/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
         String password = passwordEncoder.encode(reqeust.password());
         try {
             User createdUser = userRepository.save(new User(name, email, password));
-            return new UserResponse(createdUser);
+            return UserResponse.of(createdUser);
         } catch (DataIntegrityViolationException e) {
             throw new UserEmailDuplicatedException();
         }
@@ -41,6 +41,6 @@ public class UserService {
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new LoginFailedException();
         }
-        return new UserResponse(user);
+        return UserResponse.of(user);
     }
 }

--- a/backend/src/main/java/com/nahowo/rushTicket/service/VenueService.java
+++ b/backend/src/main/java/com/nahowo/rushTicket/service/VenueService.java
@@ -22,7 +22,7 @@ public class VenueService {
 
     public List<VenueResponse> getVenues() {
         return venueRepository.findAll()
-            .stream().map((VenueResponse::new))
+            .stream().map((VenueResponse::of))
             .toList();
     }
 
@@ -40,6 +40,6 @@ public class VenueService {
                 availabilities.put(day, VenueStatus.AVAILABLE);
             }
         }
-        return new VenueDetailResponse(venue, availabilities);
+        return VenueDetailResponse.of(venue, availabilities);
     }
 }


### PR DESCRIPTION
### 전체
- 오류/응답 코드, 예외 클래스 추가
- 필요한 도메인에 @Getter 추가
- 필요한 도메인에 상태 변경 메서드 추가
- 응답 DTO도 record를 사용하도록 변경, 필요한 경우 정적 팩토리 메서드 적용

### 이벤트 조회
- 이벤트 전체 목록 조회
- 이벤트 상세 내용 조회
  - 일정/좌석 상태 조회
  - 중첩 DTO 사용

### 이벤트 예매
- 일정/좌석 선택 후 예매

### 예매 취소
- 예매 티켓 취소

### 예매 티켓 사용
- 예매 티켓 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browse events and view detailed event information.
  * Check seat availability by event/date-time.
  * Book seats, cancel bookings, and mark tickets as used.
  * Consistent success messages across new operations.

* **Bug Fixes**
  * Deleted events are now excluded from event listings.

* **Refactor**
  * Standardized response shapes for events, venues, and users.
  * Clearer error handling for missing or invalid tickets and seat statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->